### PR TITLE
+ fix consecutive run failure with empty git-repo-path

### DIFF
--- a/entrypoint.sh
+++ b/entrypoint.sh
@@ -99,6 +99,7 @@ done
 
 [ -z "$DRY_RUN" ] || exit
 
+cd "${GIT_REPO_PATH}"
 git add .
 
 if ! git diff-index --quiet HEAD --; then


### PR DESCRIPTION
```
docker run
 -v $(pwd)/.kube:/backup/.kube:ro
 -v $(pwd)/.ssh:/backup/.ssh:ro
 -e GIT_REPO="ssh://git@githost123:2222/kube-backup"
 -e GIT_PREFIX_PATH="prod2"
 -e NAMESPACES="monitoring"
 quay.io/plange/kube-backup:1.12.0-1

Cloning into '/backup/git'...
remote: Enumerating objects: 177, done.
remote: Counting objects: 100% (177/177), done.
remote: Compressing objects: 100% (93/93), done.
remote: Total 177 (delta 91), reused 162 (delta 82)
Receiving objects: 100% (177/177), 43.60 KiB | 1.09 MiB/s, done.
Resolving deltas: 100% (91/91), done.
Already on 'master'
Your branch is up to date with 'origin/master'.
rm 'prod2/clusterrole.yaml'
...
Exporting resource: storageclass
Exporting resource: clusterrole
Exporting resource: clusterrolebinding
Exporting resource: customresourcedefinition
[monitoring] Exporting resources: ingress
[monitoring] Exporting resources: deployment
[monitoring] Exporting resources: configmap
ß[monitoring] Exporting resources: svc
[monitoring] Exporting resources: rc
[monitoring] Exporting resources: ds
[monitoring] Exporting resources: networkpolicy
[monitoring] Exporting resources: statefulset
[monitoring] Exporting resources: cronjob
[monitoring] Exporting resources: pvc
/backup/git/prod2
fatal: Unable to read current working directory: No such file or directory

```